### PR TITLE
Update supported sizes

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -3,6 +3,7 @@ import { registerBidder } from '../src/adapters/bidderFactory';
 const VERSION = '3.0.1';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = document.location.protocol + '//btlr.sharethrough.com/header-bid/v1';
+const DEFAULT_SIZE = [1, 1];
 
 export const sharethroughAdapterSpec = {
   code: BIDDER_CODE,
@@ -52,8 +53,8 @@ export const sharethroughAdapterSpec = {
     }
 
     const creative = body.creatives[0];
-    let size = [0, 0];
-    if (req.strData.stayInIframe) {
+    let size = DEFAULT_SIZE;
+    if (req.strData.iframeSize || req.strData.sizes.length) {
       size = req.strData.iframeSize != undefined
         ? req.strData.iframeSize
         : getLargestSize(req.strData.sizes);
@@ -76,9 +77,9 @@ export const sharethroughAdapterSpec = {
   getUserSyncs: (syncOptions, serverResponses) => {
     const syncs = [];
     const shouldCookieSync = syncOptions.pixelEnabled &&
-                             serverResponses.length > 0 &&
-                             serverResponses[0].body &&
-                             serverResponses[0].body.cookieSyncUrls;
+      serverResponses.length > 0 &&
+      serverResponses[0].body &&
+      serverResponses[0].body.cookieSyncUrls;
 
     if (shouldCookieSync) {
       serverResponses[0].body.cookieSyncUrls.forEach(url => {
@@ -101,7 +102,7 @@ function getLargestSize(sizes) {
     } else {
       return prev
     }
-  }, [0, 0]);
+  });
 }
 
 function generateAd(body, req) {

--- a/modules/sharethroughBidAdapter.md
+++ b/modules/sharethroughBidAdapter.md
@@ -3,7 +3,7 @@
 ```
 Module Name: Sharethrough Bidder Adapter
 Module Type: Bidder Adapter
-Maintainer: jchau@sharethrough.com && cpan@sharethrough.com
+Maintainer: pubgrowth.engineering@sharethrough.com
 ```
 
 # Description

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -74,6 +74,30 @@ const prebidRequests = [
       sizes: [[300, 250], [300, 300], [250, 250], [600, 50]]
     }
   },
+  {
+    method: 'GET',
+    url: document.location.protocol + '//btlr.sharethrough.com' + '/header-bid/v1',
+    data: {
+      bidId: 'bidId',
+      placement_key: 'pKey'
+    },
+    strData: {
+      stayInIframe: false,
+      sizes: [[0, 0]]
+    }
+  },
+  {
+    method: 'GET',
+    url: document.location.protocol + '//btlr.sharethrough.com' + '/header-bid/v1',
+    data: {
+      bidId: 'bidId',
+      placement_key: 'pKey'
+    },
+    strData: {
+      stayInIframe: false,
+      sizes: [[300, 250], [300, 300], [250, 250], [600, 50]]
+    }
+  },
 ];
 
 const bidderResponse = {
@@ -169,8 +193,8 @@ describe('sharethrough adapter spec', function () {
     it('returns a correctly parsed out response', function () {
       expect(spec.interpretResponse(bidderResponse, prebidRequests[0])[0]).to.include(
         {
-          width: 0,
-          height: 0,
+          width: 1,
+          height: 1,
           cpm: 12.34,
           creativeId: 'aCreativeId',
           dealId: 'aDealId',
@@ -199,6 +223,34 @@ describe('sharethrough adapter spec', function () {
         {
           width: 500,
           height: 500,
+          cpm: 12.34,
+          creativeId: 'aCreativeId',
+          dealId: 'aDealId',
+          currency: 'USD',
+          netRevenue: true,
+          ttl: 360,
+        });
+    });
+
+    it('returns a correctly parsed out response with explicitly defined size when strData.stayInIframe is false and strData.sizes contains [0, 0] only', function () {
+      expect(spec.interpretResponse(bidderResponse, prebidRequests[3])[0]).to.include(
+        {
+          width: 0,
+          height: 0,
+          cpm: 12.34,
+          creativeId: 'aCreativeId',
+          dealId: 'aDealId',
+          currency: 'USD',
+          netRevenue: true,
+          ttl: 360,
+        });
+    });
+
+    it('returns a correctly parsed out response with explicitly defined size when strData.stayInIframe is false and strData.sizes contains multiple sizes', function () {
+      expect(spec.interpretResponse(bidderResponse, prebidRequests[4])[0]).to.include(
+        {
+          width: 300,
+          height: 300,
           cpm: 12.34,
           creativeId: 'aCreativeId',
           dealId: 'aDealId',


### PR DESCRIPTION
- Default size returned changed from 0x0 to 1x1 to support PrebidServer
- Now will always respect the bid sizes supported when configured

Co-authored-by: Josh Becker <jbecker@sharethrough.com>