### PR TITLE
Add 3 pbjs callbacks to the adapter

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -92,7 +92,13 @@ export const sharethroughAdapterSpec = {
     }
 
     return syncs;
-  }
+  },
+
+  onTimeout: (data) => {},
+
+  onBidWon: (bid) => {},
+
+  onSetTargeting: (bid) => {}
 }
 
 function getLargestSize(sizes) {

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -94,10 +94,13 @@ export const sharethroughAdapterSpec = {
     return syncs;
   },
 
+  // Empty implementation for prebid core to be able to find it
   onTimeout: (data) => {},
 
+  // Empty implementation for prebid core to be able to find it
   onBidWon: (bid) => {},
 
+  // Empty implementation for prebid core to be able to find it
   onSetTargeting: (bid) => {}
 }
 


### PR DESCRIPTION
I did a few tests and I'm a little confused about the ask...

Before I implement any of the required functions (`onBidWon()`, `onSetTargeting()`, `onTimeout()`):
- `pbjs.getAllPrebidWinningBids()` already returns sharethrough winning bids, tied to the sharethrough bidder code
- `pbjs.getAdServerTargeting()` does return an empty object for each placement
...making me confused about the ticket description that states that some other bidders would show up as winners. So I'm not sure if I'm just missing something.

I have been able to confirm that adding an empty `onSetTargeting()` function changes the result of `pbjs.getAdServerTargeting()` returning some targeting data instead of empty objects. I cannot tell if the other 2 (`onBidWon()`,  `onTimeout()`) bring anything, I even haven't been able to see `onBidWon()` being called even though sharethrough had winning bids. I added them to the PR nonetheless.

https://www.pivotaltracker.com/story/show/165641393