### PR TITLE
Add support for supply chain object module to Sharethrough bid adapter

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -41,6 +41,10 @@ export const sharethroughAdapterSpec = {
         query.ttduid = bidRequest.userId.tdid;
       }
 
+      if (bidRequest.schain) {
+        query.schain = JSON.stringify(bidRequest.schain);
+      }
+
       // Data that does not need to go to the server,
       // but we need as part of interpretResponse()
       const strData = {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -280,6 +280,31 @@ describe('sharethrough adapter spec', function () {
         }
       });
     });
+
+    it('should add a supply chain parameter if schain is present', function() {
+      // shallow copy of the first bidRequest obj, so we don't mutate
+      const bidRequest = Object.assign({}, bidRequests[0]);
+      bidRequest['schain'] = {
+        ver: '1.0',
+        complete: 1,
+        nodes: [
+          {
+            asi: 'directseller.com',
+            sid: '00001',
+            rid: 'BidRequest1',
+            hp: 1
+          }
+        ]
+      };
+
+      const builtBidRequest = spec.buildRequests([bidRequest])[0];
+      expect(builtBidRequest.data.schain).to.eq(JSON.stringify(bidRequest.schain));
+    });
+
+    it('should not add a supply chain parameter if schain is missing', function() {
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      expect(bidRequest.data).to.not.include.any.keys('schain');
+    });
   });
 
   describe('.interpretResponse', function () {


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Does this change affect user-facing APIs or examples documented on http://prebid.org?

## Description of change
- Sharethrough's bid adapter has been updated to support the supply chain object module.
- pubgrowth.engineering@sharethrough.com
**- TODO: A link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/**