### PR TITLE
Always use HTTPS to request sfp.js

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,6 +1,6 @@
 import { registerBidder } from '../src/adapters/bidderFactory';
 
-const VERSION = '3.2.0';
+const VERSION = '3.2.1';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = 'https://btlr.sharethrough.com/WYu2BXv1/v1';
 const DEFAULT_SIZE = [1, 1];

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -148,7 +148,7 @@ function generateAd(body, req) {
 
   if (req.strData.skipIframeBusting) {
     // Don't break out of iframe
-    adMarkup = adMarkup + `<script src="//native.sharethrough.com/assets/sfp.js"></script>`;
+    adMarkup = adMarkup + `<script src="https://native.sharethrough.com/assets/sfp.js"></script>`;
   } else {
     // Add logic to the markup that detects whether or not in top level document is accessible
     // this logic will deploy sfp.js and/or iframe buster script(s) as appropriate


### PR DESCRIPTION
In the edge case where we are forced to serve within an iframe, we serve `sfp.js` protocol relative - this will force HTTPS.