### PR TITLE
Update universal ids to include ID5, SharedID, and LiveIntent ID

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -136,11 +136,9 @@ export const sharethroughAdapterSpec = {
 };
 
 function handleUniversalIds(bidRequest) {
-  const universalIds = {};
+  if (!bidRequest.userId) return {};
 
-  if (!bidRequest.userId) {
-    return {};
-  }
+  const universalIds = {};
 
   const ttd = utils.deepAccess(bidRequest, 'userId.tdid');
   if (ttd) universalIds.ttduid = ttd;

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -142,36 +142,25 @@ function handleUniversalIds(bidRequest) {
     return {};
   }
 
-  if (bidRequest.userId.tdid) {
-    universalIds.ttduid = bidRequest.userId.tdid;
-  }
+  const ttd = utils.deepAccess(bidRequest, 'userId.tdid');
+  if (ttd) universalIds.ttduid = ttd;
 
-  if (bidRequest.userId.pubcid) {
-    universalIds.pubcid = bidRequest.userId.pubcid;
-  } else if (bidRequest.crumbs && bidRequest.crumbs.pubcid) {
-    universalIds.pubcid = bidRequest.crumbs.pubcid;
-  }
+  const pubc = utils.deepAccess(bidRequest, 'userId.pubcid') || utils.deepAccess(bidRequest, 'crumbs.pubcid');
+  if (pubc) universalIds.pubcid = pubc;
 
-  if (bidRequest.userId.idl_env) {
-    universalIds.idluid = bidRequest.userId.idl_env;
-  }
+  const idl = utils.deepAccess(bidRequest, 'userId.idl_env');
+  if (idl) universalIds.idluid = idl;
 
-  if (bidRequest.userId.id5id) {
-    universalIds.id5uid = bidRequest.userId.id5id;
-  }
+  const id5 = utils.deepAccess(bidRequest, 'userId.id5id');
+  if (id5) universalIds.id5uid = id5;
 
-  if (bidRequest.userId.lipb && bidRequest.userId.lipb.lipbid) {
-    universalIds.liuid = bidRequest.userId.lipb.lipbid;
-  }
+  const lipb = utils.deepAccess(bidRequest, 'userId.lipb.lipbid');
+  if (lipb) universalIds.liuid = lipb;
 
-  if (bidRequest.userId.sharedid) {
-    if (bidRequest.userId.sharedid.id) {
-      universalIds.shduid = bidRequest.userId.sharedid.id;
-    }
-    if (bidRequest.userId.sharedid.third) {
-      universalIds.shd3id = bidRequest.userId.sharedid.third;
-    }
-  }
+  const shd = utils.deepAccess(bidRequest, 'userId.sharedid.id');
+  if (shd) universalIds.shduid = shd;
+  const shd3 = utils.deepAccess(bidRequest, 'userId.sharedid.third');
+  if (shd3) universalIds.shd3id = shd3;
 
   return universalIds;
 }

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,7 +1,7 @@
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 
-const VERSION = '3.3.0';
+const VERSION = '3.3.1';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = 'https://btlr.sharethrough.com/WYu2BXv1/v1';
 const DEFAULT_SIZE = [1, 1];
@@ -31,6 +31,8 @@ export const sharethroughAdapterSpec = {
         strVersion: VERSION
       };
 
+      Object.assign(query, handleUniversalIds(bidRequest));
+
       const nonHttp = sharethroughInternal.getProtocol().indexOf('http') < 0;
       query.secure = nonHttp || (sharethroughInternal.getProtocol().indexOf('https') > -1);
 
@@ -44,20 +46,6 @@ export const sharethroughAdapterSpec = {
 
       if (bidderRequest && bidderRequest.uspConsent) {
         query.us_privacy = bidderRequest.uspConsent
-      }
-
-      if (bidRequest.userId && bidRequest.userId.tdid) {
-        query.ttduid = bidRequest.userId.tdid;
-      }
-
-      if (bidRequest.userId && bidRequest.userId.pubcid) {
-        query.pubcid = bidRequest.userId.pubcid;
-      } else if (bidRequest.crumbs && bidRequest.crumbs.pubcid) {
-        query.pubcid = bidRequest.crumbs.pubcid;
-      }
-
-      if (bidRequest.userId && bidRequest.userId.idl_env) {
-        query.idluid = bidRequest.userId.idl_env;
       }
 
       if (bidRequest.schain) {
@@ -146,6 +134,47 @@ export const sharethroughAdapterSpec = {
   // Empty implementation for prebid core to be able to find it
   onSetTargeting: (bid) => {}
 };
+
+function handleUniversalIds(bidRequest) {
+  const universalIds = {};
+
+  if (!bidRequest.userId) {
+    return {};
+  }
+
+  if (bidRequest.userId.tdid) {
+    universalIds.ttduid = bidRequest.userId.tdid;
+  }
+
+  if (bidRequest.userId.pubcid) {
+    universalIds.pubcid = bidRequest.userId.pubcid;
+  } else if (bidRequest.crumbs && bidRequest.crumbs.pubcid) {
+    universalIds.pubcid = bidRequest.crumbs.pubcid;
+  }
+
+  if (bidRequest.userId.idl_env) {
+    universalIds.idluid = bidRequest.userId.idl_env;
+  }
+
+  if (bidRequest.userId.id5id) {
+    universalIds.id5uid = bidRequest.userId.id5id;
+  }
+
+  if (bidRequest.userId.lipb && bidRequest.userId.lipb.lipbid) {
+    universalIds.liuid = bidRequest.userId.lipb.lipbid;
+  }
+
+  if (bidRequest.userId.sharedid) {
+    if (bidRequest.userId.sharedid.id) {
+      universalIds.shduid = bidRequest.userId.sharedid.id;
+    }
+    if (bidRequest.userId.sharedid.third) {
+      universalIds.shd3id = bidRequest.userId.sharedid.third;
+    }
+  }
+
+  return universalIds;
+}
 
 function getLargestSize(sizes) {
   function area(size) {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -15,7 +15,12 @@ const bidRequests = [
     userId: {
       tdid: 'fake-tdid',
       pubcid: 'fake-pubcid',
-      idl_env: 'fake-identity-link'
+      idl_env: 'fake-identity-link',
+      id5id: 'fake-id5id',
+      sharedid: {id: 'fake-sharedid', third: 'fake-sharedthird'},
+      lipb: {
+        lipbid: 'fake-lipbid'
+      }
     },
     crumbs: {
       pubcid: 'fake-pubcid-in-crumbs-obj'
@@ -339,6 +344,22 @@ describe('sharethrough adapter spec', function() {
     it('should add the idluid parameter if a bid request contains a value for Identity Link from Live Ramp', function() {
       const bidRequest = spec.buildRequests(bidRequests)[0];
       expect(bidRequest.data.idluid).to.eq('fake-identity-link');
+    });
+
+    it('should add the id5uid parameter if a bid request contains a value for ID5', function() {
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      expect(bidRequest.data.id5uid).to.eq('fake-id5id');
+    });
+
+    it('should add the shduid parameter if a bid request contains a value for Shared ID', function() {
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      expect(bidRequest.data.shduid).to.eq('fake-sharedid');
+      expect(bidRequest.data.shd3id).to.eq('fake-sharedthird');
+    });
+
+    it('should add the liuid parameter if a bid request contains a value for LiveIntent ID', function() {
+      const bidRequest = spec.buildRequests(bidRequests)[0];
+      expect(bidRequest.data.liuid).to.eq('fake-lipbid');
     });
 
     it('should add Sharethrough specific parameters', function() {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { sharethroughAdapterSpec, sharethroughInternal } from 'modules/sharethroughBidAdapter.js';
 import { newBidder } from 'src/adapters/bidderFactory.js';
+import * as utils from '../../../src/utils.js';
 
 const spec = newBidder(sharethroughAdapterSpec).getSpec();
 const bidRequests = [
@@ -332,6 +333,15 @@ describe('sharethrough adapter spec', function() {
       ' userId object of the bidrequest', function() {
       const bidRequest = spec.buildRequests(bidRequests)[0];
       expect(bidRequest.data.pubcid).to.eq('fake-pubcid');
+    });
+
+    it('should add the pubcid parameter if a bid request contains a value for the Publisher Common ID Module in the' +
+      ' crumbs object of the bidrequest', function() {
+      const bidData = utils.deepClone(bidRequests);
+      delete bidData[0].userId.pubcid;
+
+      const bidRequest = spec.buildRequests(bidData)[0];
+      expect(bidRequest.data.pubcid).to.eq('fake-pubcid-in-crumbs-obj');
     });
 
     it('should add the pubcid parameter if a bid request contains a value for the Publisher Common ID Module in the' +


### PR DESCRIPTION
Update universal ids to include ID5, SharedID, and LiveIntent ID.

[#176447070](https://www.pivotaltracker.com/story/show/176447070)

Co-authored-by: Mathieu Pheulpin <mpheulpin@sharethrough.com>