### PR TITLE
Parse and send global placement id

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -2,7 +2,7 @@ import { registerBidder } from '../src/adapters/bidderFactory.js';
 import * as utils from '../src/utils.js';
 import { config } from '../src/config.js';
 
-const VERSION = '3.4.0';
+const VERSION = '3.4.1';
 const BIDDER_CODE = 'sharethrough';
 const STR_ENDPOINT = 'https://btlr.sharethrough.com/WYu2BXv1/v1';
 const DEFAULT_SIZE = [1, 1];

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -29,8 +29,13 @@ export const sharethroughAdapterSpec = {
         instant_play_capable: canAutoPlayHTML5Video(),
         hbSource: 'prebid',
         hbVersion: '$prebid.version$',
-        strVersion: VERSION
+        strVersion: VERSION,
       };
+
+      const gpid = utils.deepAccess(bidRequest, 'ortb2Imp.ext.data.pbadslot');
+      if (gpid) {
+        query.gpid = gpid;
+      }
 
       Object.assign(query, handleUniversalIds(bidRequest));
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -14,6 +14,13 @@ const bidRequests = [
     params: {
       pkey: 'aaaa1111'
     },
+    ortb2Imp: {
+      ext: {
+        data: {
+          pbadslot: 'adslot-id-1'
+        }
+      }
+    },
     userId: {
       tdid: 'fake-tdid',
       pubcid: 'fake-pubcid',
@@ -405,6 +412,18 @@ describe('sharethrough adapter spec', function() {
 
       const builtBidRequest = spec.buildRequests([bidRequest])[0];
       expect(builtBidRequest.data.schain).to.eq(JSON.stringify(bidRequest.schain));
+    });
+
+    describe('gpid', () => {
+      it('should include the gpid param if pbadslot is found in ortb2Imp in the bid request', () => {
+        const bidRequest = spec.buildRequests(bidRequests)[0];
+        expect(bidRequest.data.gpid).to.be('adslot-id-1')
+      });
+
+      it('should not include the gpid param if pbadslot is not found in ortb2Imp in the bid request', () => {
+        const bidRequest = spec.buildRequests(bidRequests)[1];
+        expect(bidRequest.data).to.not.include.any.keys('gpid');
+      });
     });
 
     it('should add badv if provided', () => {


### PR DESCRIPTION
I looked at other bidders who implement GPID and they parse `ortb2Imp.ext.data.pbadslot` (see prebid/Prebid.js#6826 and prebid/Prebid.js#6813)

Looking into [prebid docs](https://docs.prebid.org/features/pbAdSlot.html), it does look like this is where they expect publishers to set their ad slot IDs.

https://sharethrough.atlassian.net/browse/PGE-178206244