### PR TITLE
Ensure that a separate openRTB request object is created for each bid request

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -5,7 +5,7 @@ import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { createEidsArray } from './userId/eids.js';
 import find from 'core-js-pure/features/array/find.js';
 
-const VERSION = '4.0.0';
+const VERSION = '4.0.1';
 const BIDDER_CODE = 'sharethrough';
 const SUPPLY_ID = 'WYu2BXv1';
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -141,16 +141,16 @@ export const sharethroughAdapterSpec = {
       };
     }).filter(imp => !!imp);
 
-    return {
-      method: 'POST',
-      url: STR_ENDPOINT,
-      data: {
-        ...req,
-        imp: imps,
-      },
-      bidRequests,
-      bidderRequest,
-    };
+    return imps.map(impression => {
+      return {
+        method: 'POST',
+        url: STR_ENDPOINT,
+        data: {
+          ...req,
+          imp: [impression],
+        },
+      };
+    });
   },
 
   interpretResponse: ({ body }, req) => {

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -149,6 +149,9 @@ export const sharethroughAdapterSpec = {
           ...req,
           imp: [impression],
         },
+        strData: {
+          mediaType: impression.mediaType
+        }
       };
     });
   },
@@ -159,8 +162,6 @@ export const sharethroughAdapterSpec = {
     }
 
     return body.seatbid[0].bid.map(bid => {
-      const request = matchRequest(bid.impid, req);
-
       const response = {
         requestId: bid.impid,
         width: +bid.w,
@@ -168,7 +169,7 @@ export const sharethroughAdapterSpec = {
         cpm: +bid.price,
         creativeId: bid.crid,
         dealId: bid.dealid || null,
-        mediaType: request.mediaTypes && request.mediaTypes.video ? VIDEO : BANNER,
+        mediaType: req.data.imp[0].video ? VIDEO : BANNER,
         currency: body.cur || 'USD',
         netRevenue: true,
         ttl: 360,

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -178,64 +178,76 @@ describe('sharethrough adapter spec', function() {
     describe('buildRequests', function() {
       describe('top level object', () => {
         it('should build openRTB request', () => {
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
+          const builtRequests = spec.buildRequests(bidRequests, bidderRequest);
 
-          expect(builtRequest.method).to.equal('POST');
-          expect(builtRequest.url).not.to.be.undefined;
-          expect(builtRequest.options).to.be.undefined;
-          expect(builtRequest.bidderRequest).to.deep.equal(bidderRequest);
+          const expectedImpValues = [
+            {
+              id: 'bidId1',
+              tagid: 'aaaa1111',
+              secure: 1,
+              bidfloor: 42,
+            },
+            {
+              id: 'bidId2',
+              tagid: 'bbbb2222',
+              secure: 1,
+              bidfloor: 42,
+            }
+          ]
 
-          const openRtbReq = builtRequest.data;
-          expect(openRtbReq.id).not.to.be.undefined;
-          expect(openRtbReq.cur).to.deep.equal(['USD']);
-          expect(openRtbReq.tmax).to.equal(242);
+          builtRequests.map((builtRequest, rIndex) => {
+            expect(builtRequest.method).to.equal('POST');
+            expect(builtRequest.url).not.to.be.undefined;
+            expect(builtRequest.options).to.be.undefined;
+            expect(builtRequest.bidderRequest).to.deep.equal(bidderRequest);
 
-          expect(openRtbReq.site.domain).not.to.be.undefined;
-          expect(openRtbReq.site.page).not.to.be.undefined;
-          expect(openRtbReq.site.ref).to.equal('https://referer.com');
+            const openRtbReq = builtRequest.data;
+            expect(openRtbReq.id).not.to.be.undefined;
+            expect(openRtbReq.cur).to.deep.equal(['USD']);
+            expect(openRtbReq.tmax).to.equal(242);
 
-          const expectedEids = {
-            'liveramp.com': { id: 'fake-identity-link' },
-            'id5-sync.com': { id: 'fake-id5id' },
-            'pubcid.org': { id: 'fake-pubcid' },
-            'adserver.org': { id: 'fake-tdid' },
-            'criteo.com': { id: 'fake-criteo' },
-            'britepool.com': { id: 'fake-britepool' },
-            'liveintent.com': { id: 'fake-lipbid' },
-            'intentiq.com': { id: 'fake-intentiq' },
-            'crwdcntrl.net': { id: 'fake-lotame' },
-            'parrable.com': { id: 'fake-parrable' },
-            'netid.de': { id: 'fake-netid' },
-            'chrome.com': { id: 'fake-flocid' },
-          };
-          expect(openRtbReq.user.ext.eids).to.be.an('array').that.have.length(Object.keys(expectedEids).length);
-          for (const eid of openRtbReq.user.ext.eids) {
-            expect(Object.keys(expectedEids)).to.include(eid.source);
-            expect(eid.uids[0].id).to.equal(expectedEids[eid.source].id);
-            expect(eid.uids[0].atype).to.be.ok;
-          }
+            expect(openRtbReq.site.domain).not.to.be.undefined;
+            expect(openRtbReq.site.page).not.to.be.undefined;
+            expect(openRtbReq.site.ref).to.equal('https://referer.com');
 
-          expect(openRtbReq.device.ua).to.equal(navigator.userAgent);
-          expect(openRtbReq.regs.coppa).to.equal(1);
+            const expectedEids = {
+              'liveramp.com': { id: 'fake-identity-link' },
+              'id5-sync.com': { id: 'fake-id5id' },
+              'pubcid.org': { id: 'fake-pubcid' },
+              'adserver.org': { id: 'fake-tdid' },
+              'criteo.com': { id: 'fake-criteo' },
+              'britepool.com': { id: 'fake-britepool' },
+              'liveintent.com': { id: 'fake-lipbid' },
+              'intentiq.com': { id: 'fake-intentiq' },
+              'crwdcntrl.net': { id: 'fake-lotame' },
+              'parrable.com': { id: 'fake-parrable' },
+              'netid.de': { id: 'fake-netid' },
+              'chrome.com': { id: 'fake-flocid' },
+            };
+            expect(openRtbReq.user.ext.eids).to.be.an('array').that.have.length(Object.keys(expectedEids).length);
+            for (const eid of openRtbReq.user.ext.eids) {
+              expect(Object.keys(expectedEids)).to.include(eid.source);
+              expect(eid.uids[0].id).to.equal(expectedEids[eid.source].id);
+              expect(eid.uids[0].atype).to.be.ok;
+            }
 
-          expect(openRtbReq.source.ext.version).not.to.be.undefined;
-          expect(openRtbReq.source.ext.str).not.to.be.undefined;
-          expect(openRtbReq.source.ext.schain).to.deep.equal(bidRequests[0].schain);
+            expect(openRtbReq.device.ua).to.equal(navigator.userAgent);
+            expect(openRtbReq.regs.coppa).to.equal(1);
 
-          expect(openRtbReq.bcat).to.deep.equal(bidRequests[0].params.bcat);
-          expect(openRtbReq.badv).to.deep.equal(bidRequests[0].params.badv);
+            expect(openRtbReq.source.ext.version).not.to.be.undefined;
+            expect(openRtbReq.source.ext.str).not.to.be.undefined;
+            expect(openRtbReq.source.ext.schain).to.deep.equal(bidRequests[0].schain);
 
-          expect(openRtbReq.imp).to.have.length(2);
+            expect(openRtbReq.bcat).to.deep.equal(bidRequests[0].params.bcat);
+            expect(openRtbReq.badv).to.deep.equal(bidRequests[0].params.badv);
 
-          expect(openRtbReq.imp[0].id).to.equal('bidId1');
-          expect(openRtbReq.imp[0].tagid).to.equal('aaaa1111');
-          expect(openRtbReq.imp[0].secure).to.equal(1);
-          expect(openRtbReq.imp[0].bidfloor).to.equal(42);
+            expect(openRtbReq.imp).to.have.length(1);
 
-          expect(openRtbReq.imp[1].id).to.equal('bidId2');
-          expect(openRtbReq.imp[1].tagid).to.equal('bbbb2222');
-          expect(openRtbReq.imp[1].secure).to.equal(1);
-          expect(openRtbReq.imp[1].bidfloor).to.equal(42);
+            expect(openRtbReq.imp[rIndex].id).to.equal(expectedImpValues[rIndex].id);
+            expect(openRtbReq.imp[rIndex].tagid).to.equal(expectedImpValues[rIndex].tagid);
+            expect(openRtbReq.imp[rIndex].secure).to.equal(expectedImpValues[rIndex].secure);
+            expect(openRtbReq.imp[rIndex].bidfloor).to.equal(expectedImpValues[rIndex].bidfloor);
+          });
         });
 
         it('should have empty eid array if no id is provided', () => {

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -199,7 +199,6 @@ describe('sharethrough adapter spec', function() {
             expect(builtRequest.method).to.equal('POST');
             expect(builtRequest.url).not.to.be.undefined;
             expect(builtRequest.options).to.be.undefined;
-            expect(builtRequest.bidderRequest).to.deep.equal(bidderRequest);
 
             const openRtbReq = builtRequest.data;
             expect(openRtbReq.id).not.to.be.undefined;
@@ -243,15 +242,15 @@ describe('sharethrough adapter spec', function() {
 
             expect(openRtbReq.imp).to.have.length(1);
 
-            expect(openRtbReq.imp[rIndex].id).to.equal(expectedImpValues[rIndex].id);
-            expect(openRtbReq.imp[rIndex].tagid).to.equal(expectedImpValues[rIndex].tagid);
-            expect(openRtbReq.imp[rIndex].secure).to.equal(expectedImpValues[rIndex].secure);
-            expect(openRtbReq.imp[rIndex].bidfloor).to.equal(expectedImpValues[rIndex].bidfloor);
+            expect(openRtbReq.imp[0].id).to.equal(expectedImpValues[rIndex].id);
+            expect(openRtbReq.imp[0].tagid).to.equal(expectedImpValues[rIndex].tagid);
+            expect(openRtbReq.imp[0].secure).to.equal(expectedImpValues[rIndex].secure);
+            expect(openRtbReq.imp[0].bidfloor).to.equal(expectedImpValues[rIndex].bidfloor);
           });
         });
 
         it('should have empty eid array if no id is provided', () => {
-          const openRtbReq = spec.buildRequests([bidRequests[1]], bidderRequest).data;
+          const openRtbReq = spec.buildRequests([bidRequests[1]], bidderRequest)[0].data;
 
           expect(openRtbReq.user.ext.eids).to.deep.equal([]);
         });
@@ -265,8 +264,7 @@ describe('sharethrough adapter spec', function() {
               consentString: 'consent',
             };
 
-            const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-            const openRtbReq = builtRequest.data;
+            const openRtbReq = spec.buildRequests(bidRequests, bidderRequest)[0].data;
 
             expect(openRtbReq.regs.ext.gdpr).to.equal(1);
             expect(openRtbReq.user.ext.consent).to.equal('consent');
@@ -277,8 +275,7 @@ describe('sharethrough adapter spec', function() {
               gdprApplies: false,
             };
 
-            const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-            const openRtbReq = builtRequest.data;
+            const openRtbReq = spec.buildRequests(bidRequests, bidderRequest)[0].data;
 
             expect(openRtbReq.regs.ext.gdpr).to.equal(0);
             expect(openRtbReq.user.ext.consent).to.be.undefined;
@@ -289,8 +286,7 @@ describe('sharethrough adapter spec', function() {
           it('should populate request accordingly when us privacy applies', () => {
             bidderRequest.uspConsent = 'consent';
 
-            const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-            const openRtbReq = builtRequest.data;
+            const openRtbReq = spec.buildRequests(bidRequests, bidderRequest)[0].data;
 
             expect(openRtbReq.regs.ext.us_privacy).to.equal('consent');
           });
@@ -300,8 +296,7 @@ describe('sharethrough adapter spec', function() {
           it('should populate request accordingly when coppa does not apply', () => {
             config.setConfig({ coppa: false });
 
-            const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-            const openRtbReq = builtRequest.data;
+            const openRtbReq = spec.buildRequests(bidRequests, bidderRequest)[0].data;
 
             expect(openRtbReq.regs.coppa).to.equal(0);
           });
@@ -310,46 +305,42 @@ describe('sharethrough adapter spec', function() {
 
       describe('universal id', () => {
         it('should include gpid when universal id is provided', () => {
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-          const openRtbReq = builtRequest.data;
+          const requests = spec.buildRequests(bidRequests, bidderRequest);
 
-          expect(openRtbReq.imp[0].ext.gpid).to.equal('universal-id');
-          expect(openRtbReq.imp[1].ext).to.be.undefined;
+          expect(requests[0].data.imp[0].ext.gpid).to.equal('universal-id');
+          expect(requests[1].data.imp[0].ext).to.be.undefined;
         });
       });
 
       describe('secure flag', () => {
         it('should be positive when protocol is https', () => {
           protocolStub.returns('https');
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-          const openRtbReq = builtRequest.data;
+          const requests = spec.buildRequests(bidRequests, bidderRequest);
 
-          expect(openRtbReq.imp[0].secure).to.equal(1);
-          expect(openRtbReq.imp[1].secure).to.equal(1);
+          expect(requests[0].data.imp[0].secure).to.equal(1);
+          expect(requests[1].data.imp[0].secure).to.equal(1);
         });
 
         it('should be negative when protocol is http', () => {
           protocolStub.returns('http');
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-          const openRtbReq = builtRequest.data;
+          const requests = spec.buildRequests(bidRequests, bidderRequest);
 
-          expect(openRtbReq.imp[0].secure).to.equal(0);
-          expect(openRtbReq.imp[1].secure).to.equal(0);
+          expect(requests[0].data.imp[0].secure).to.equal(0);
+          expect(requests[1].data.imp[0].secure).to.equal(0);
         });
 
         it('should be positive when protocol is neither http nor https', () => {
           protocolStub.returns('about');
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
-          const openRtbReq = builtRequest.data;
+          const requests = spec.buildRequests(bidRequests, bidderRequest);
 
-          expect(openRtbReq.imp[0].secure).to.equal(1);
-          expect(openRtbReq.imp[1].secure).to.equal(1);
+          expect(requests[0].data.imp[0].secure).to.equal(1);
+          expect(requests[1].data.imp[0].secure).to.equal(1);
         });
       });
 
       describe('banner imp', () => {
         it('should generate open rtb banner imp', () => {
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
+          const builtRequest = spec.buildRequests(bidRequests, bidderRequest)[0];
 
           const bannerImp = builtRequest.data.imp[0].banner;
           expect(bannerImp.pos).to.equal(1);
@@ -359,7 +350,7 @@ describe('sharethrough adapter spec', function() {
 
         it('should default to pos 0 if not provided', () => {
           delete bidRequests[0].mediaTypes;
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
+          const builtRequest = spec.buildRequests(bidRequests, bidderRequest)[0];
 
           const bannerImp = builtRequest.data.imp[0].banner;
           expect(bannerImp.pos).to.equal(0);
@@ -368,9 +359,9 @@ describe('sharethrough adapter spec', function() {
 
       describe('video imp', () => {
         it('should generate open rtb video imp', () => {
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
+          const builtRequest = spec.buildRequests(bidRequests, bidderRequest)[1];
 
-          const videoImp = builtRequest.data.imp[1].video;
+          const videoImp = builtRequest.data.imp[0].video;
           expect(videoImp.pos).to.equal(3);
           expect(videoImp.topframe).to.equal(1);
           expect(videoImp.skip).to.equal(1);
@@ -411,9 +402,9 @@ describe('sharethrough adapter spec', function() {
           delete bidRequests[1].mediaTypes.video.companiontype;
           delete bidRequests[1].mediaTypes.video.companionad;
 
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
+          const builtRequest = spec.buildRequests(bidRequests, bidderRequest)[1];
 
-          const videoImp = builtRequest.data.imp[1].video;
+          const videoImp = builtRequest.data.imp[0].video;
           expect(videoImp.pos).to.equal(0);
           expect(videoImp.skip).to.equal(0);
           expect(videoImp.linearity).to.equal(1);
@@ -436,10 +427,9 @@ describe('sharethrough adapter spec', function() {
 
         it('should not return a video impression if context is outstream', () => {
           bidRequests[1].mediaTypes.video.context = 'outstream';
-          const builtRequest = spec.buildRequests(bidRequests, bidderRequest);
+          const builtRequest = spec.buildRequests(bidRequests, bidderRequest)[1];
 
-          const videoImp = builtRequest.data.imp[1];
-          expect(videoImp).to.be.undefined;
+          expect(builtRequest).to.be.undefined;
         });
       });
     });
@@ -448,35 +438,36 @@ describe('sharethrough adapter spec', function() {
       let request;
       let response;
 
-      beforeEach(() => {
-        request = spec.buildRequests(bidRequests, bidderRequest);
-        response = {
-          body: {
-            seatbid: [{
-              bid: [{
-                id: '123',
-                impid: 'bidId1',
-                w: 300,
-                h: 250,
-                price: 42,
-                crid: 'creative',
-                dealid: 'deal',
-                adomain: ['domain.com'],
-                adm: 'markup',
-              }, {
-                id: '456',
-                impid: 'bidId2',
-                w: 640,
-                h: 480,
-                price: 42,
-                adm: 'vastTag',
-              }],
-            }],
-          },
-        };
-      });
 
       describe('banner', () => {
+        beforeEach(() => {
+          request = spec.buildRequests(bidRequests, bidderRequest)[0];
+          response = {
+            body: {
+              seatbid: [{
+                bid: [{
+                  id: '123',
+                  impid: 'bidId1',
+                  w: 300,
+                  h: 250,
+                  price: 42,
+                  crid: 'creative',
+                  dealid: 'deal',
+                  adomain: ['domain.com'],
+                  adm: 'markup',
+                }, {
+                  id: '456',
+                  impid: 'bidId2',
+                  w: 640,
+                  h: 480,
+                  price: 42,
+                  adm: 'vastTag',
+                }],
+              }],
+            },
+          };
+        });
+
         it('should return a banner bid', () => {
           const resp = spec.interpretResponse(response, request);
 
@@ -498,10 +489,28 @@ describe('sharethrough adapter spec', function() {
       });
 
       describe('video', () => {
+        beforeEach(() => {
+          request = spec.buildRequests(bidRequests, bidderRequest)[1];
+          response = {
+            body: {
+              seatbid: [{
+                bid: [{
+                  id: '456',
+                  impid: 'bidId2',
+                  w: 640,
+                  h: 480,
+                  price: 42,
+                  adm: 'vastTag',
+                }],
+              }],
+            },
+          };
+        });
+
         it('should return a video bid', () => {
           const resp = spec.interpretResponse(response, request);
 
-          const bannerBid = resp[1];
+          const bannerBid = resp[0];
           expect(bannerBid.requestId).to.equal('bidId2');
           expect(bannerBid.width).to.equal(640);
           expect(bannerBid.height).to.equal(480);


### PR DESCRIPTION
## Type of change
- [ x] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Update of adapter to leverage new openRTB endpoint from STX adserver, erroneously aggregated all bid requests into a single adserver request instead of preserving one request object per impression object.   This fix restores the ratio of one impression per adserver request.

