### PR TITLE
[PGE-178206904] Send Transaction ID to STX

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -4,7 +4,7 @@ import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
 import { createEidsArray } from './userId/eids.js';
 
-const VERSION = '4.2.0';
+const VERSION = '4.3.0';
 const BIDDER_CODE = 'sharethrough';
 const SUPPLY_ID = 'WYu2BXv1';
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, generateUUID, inIframe } from '../src/utils.js';
+import { deepAccess, generateUUID, inIframe, mergeDeep } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
@@ -52,6 +52,7 @@ export const sharethroughAdapterSpec = {
         ext: {},
       },
       source: {
+        tid: bidderRequest.auctionId,
         ext: {
           version: '$prebid.version$',
           str: VERSION,
@@ -80,12 +81,12 @@ export const sharethroughAdapterSpec = {
     }
 
     const imps = bidRequests.map(bidReq => {
-      const impression = {};
+      const impression = { ext: {} };
+
+      mergeDeep(impression, bidReq.ortb2Imp);
 
       const gpid = deepAccess(bidReq, 'ortb2Imp.ext.data.pbadslot');
-      if (gpid) {
-        impression.ext = { gpid: gpid };
-      }
+      if (gpid) impression.ext.gpid = gpid;
 
       const videoRequest = deepAccess(bidReq, 'mediaTypes.video');
 

--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -1,4 +1,4 @@
-import { deepAccess, generateUUID, inIframe, mergeDeep } from '../src/utils.js';
+import { deepAccess, generateUUID, inIframe } from '../src/utils.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { config } from '../src/config.js';
 import { BANNER, VIDEO } from '../src/mediaTypes.js';
@@ -52,7 +52,7 @@ export const sharethroughAdapterSpec = {
         ext: {},
       },
       source: {
-        tid: bidderRequest.auctionId,
+        tid: bidRequests[0].transactionId,
         ext: {
           version: '$prebid.version$',
           str: VERSION,
@@ -83,9 +83,10 @@ export const sharethroughAdapterSpec = {
     const imps = bidRequests.map(bidReq => {
       const impression = { ext: {} };
 
-      mergeDeep(impression, bidReq.ortb2Imp);
-
-      const gpid = deepAccess(bidReq, 'ortb2Imp.ext.data.pbadslot');
+      // mergeDeep(impression, bidReq.ortb2Imp); // leaving this out for now as we may want to leave stuff out on purpose
+      const tid = deepAccess(bidReq, 'ortb2Imp.ext.tid');
+      if (tid) impression.ext.tid = tid;
+      const gpid = deepAccess(bidReq, 'ortb2Imp.ext.gpid', deepAccess(bidReq, 'ortb2Imp.ext.data.pbadslot'));
       if (gpid) impression.ext.gpid = gpid;
 
       const videoRequest = deepAccess(bidReq, 'mediaTypes.video');

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -72,6 +72,7 @@ describe('sharethrough adapter spec', function () {
         {
           bidder: 'sharethrough',
           bidId: 'bidId1',
+          transactionId: 'transactionId1',
           sizes: [[300, 250], [300, 600]],
           params: {
             pkey: 'aaaa1111',
@@ -86,8 +87,9 @@ describe('sharethrough adapter spec', function () {
           ortb2Imp: {
             ext: {
               tid: 'transaction-id-1',
+              gpid: 'universal-id',
               data: {
-                pbadslot: 'universal-id',
+                pbadslot: 'pbadslot-id',
               },
             },
           },
@@ -137,6 +139,7 @@ describe('sharethrough adapter spec', function () {
           bidder: 'sharethrough',
           bidId: 'bidId2',
           sizes: [[600, 300]],
+          transactionId: 'transactionId2',
           params: {
             pkey: 'bbbb2222',
           },
@@ -169,7 +172,6 @@ describe('sharethrough adapter spec', function () {
         refererInfo: {
           ref: 'https://referer.com',
         },
-        auctionId: 'transactionId1',
       };
     });
 
@@ -231,7 +233,7 @@ describe('sharethrough adapter spec', function () {
             expect(openRtbReq.device.ua).to.equal(navigator.userAgent);
             expect(openRtbReq.regs.coppa).to.equal(1);
 
-            expect(openRtbReq.source.tid).to.equal(bidderRequest.auctionId);
+            expect(openRtbReq.source.tid).to.equal(bidRequests[0].transactionId);
             expect(openRtbReq.source.ext.version).not.to.be.undefined;
             expect(openRtbReq.source.ext.str).not.to.be.undefined;
             expect(openRtbReq.source.ext.schain).to.deep.equal(bidRequests[0].schain);
@@ -328,6 +330,13 @@ describe('sharethrough adapter spec', function () {
 
           expect(requests[0].data.imp[0].ext.gpid).to.equal('universal-id');
           expect(requests[1].data.imp[0].ext).to.be.empty;
+        });
+
+        it('should include gpid when pbadslot is provided without universal id', () => {
+          delete bidRequests[0].ortb2Imp.ext.gpid;
+          const requests = spec.buildRequests(bidRequests, bidderRequest);
+
+          expect(requests[0].data.imp[0].ext.gpid).to.equal('pbadslot-id');
         });
       });
 

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -85,6 +85,7 @@ describe('sharethrough adapter spec', function () {
           },
           ortb2Imp: {
             ext: {
+              tid: 'transaction-id-1',
               data: {
                 pbadslot: 'universal-id',
               },
@@ -168,6 +169,7 @@ describe('sharethrough adapter spec', function () {
         refererInfo: {
           ref: 'https://referer.com',
         },
+        auctionId: 'transactionId1',
       };
     });
 
@@ -229,6 +231,7 @@ describe('sharethrough adapter spec', function () {
             expect(openRtbReq.device.ua).to.equal(navigator.userAgent);
             expect(openRtbReq.regs.coppa).to.equal(1);
 
+            expect(openRtbReq.source.tid).to.equal(bidderRequest.auctionId);
             expect(openRtbReq.source.ext.version).not.to.be.undefined;
             expect(openRtbReq.source.ext.str).not.to.be.undefined;
             expect(openRtbReq.source.ext.schain).to.deep.equal(bidRequests[0].schain);
@@ -310,12 +313,21 @@ describe('sharethrough adapter spec', function () {
         });
       });
 
+      describe('transaction id at the impression level', () => {
+        it('should include transaction id when provided', () => {
+          const requests = spec.buildRequests(bidRequests, bidderRequest);
+
+          expect(requests[0].data.imp[0].ext.tid).to.equal('transaction-id-1');
+          expect(requests[1].data.imp[0].ext).to.be.empty;
+        });
+      });
+
       describe('universal id', () => {
         it('should include gpid when universal id is provided', () => {
           const requests = spec.buildRequests(bidRequests, bidderRequest);
 
           expect(requests[0].data.imp[0].ext.gpid).to.equal('universal-id');
-          expect(requests[1].data.imp[0].ext).to.be.undefined;
+          expect(requests[1].data.imp[0].ext).to.be.empty;
         });
       });
 


### PR DESCRIPTION
`source.tid` is transaction id at the request level
`bidReq.ortb2Imp` may carry a transaction id at the impression level (`imp.ext.tid`)

While Prebid is still figuring out how they want to do it, this is following the same implementation as TheTradeDesk did in their own adapter so we know the transaction id is at least consistent with them (since they're the one asking for it in the first place). My understanding is that if ever the Prebid committee changes the spec, they will be the one updating all adapters like they did in the past for other changes.

Followed recommendations provided by contributors here: https://github.com/prebid/Prebid.js/issues/8573

PGE-178206904