### PR TITLE
Sharethrough Bid Adapter: Support cdep

### DIFF
--- a/modules/sharethroughBidAdapter.js
+++ b/modules/sharethroughBidAdapter.js
@@ -45,6 +45,7 @@ export const sharethroughAdapterSpec = {
         dnt: navigator.doNotTrack === '1' ? 1 : 0,
         h: window.screen.height,
         w: window.screen.width,
+        ext: {},
       },
       regs: {
         coppa: config.getConfig('coppa') === true ? 1 : 0,
@@ -62,6 +63,10 @@ export const sharethroughAdapterSpec = {
       badv: deepAccess(bidderRequest.ortb2, 'badv') || bidRequests[0].params.badv || [],
       test: 0,
     };
+
+    if (bidderRequest.ortb2?.device?.ext?.cdep) {
+      req.device.ext['cdep'] = bidderRequest.ortb2.device.ext.cdep;
+    }
 
     req.user = nullish(firstPartyData.user, {});
     if (!req.user.ext) req.user.ext = {};
@@ -220,9 +225,7 @@ export const sharethroughAdapterSpec = {
     const shouldCookieSync =
       syncOptions.pixelEnabled && deepAccess(serverResponses, '0.body.cookieSyncUrls') !== undefined;
 
-    return shouldCookieSync
-      ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url }))
-      : [];
+    return shouldCookieSync ? serverResponses[0].body.cookieSyncUrls.map((url) => ({ type: 'image', url: url })) : [];
   },
 
   // Empty implementation for prebid core to be able to find it

--- a/test/spec/modules/sharethroughBidAdapter_spec.js
+++ b/test/spec/modules/sharethroughBidAdapter_spec.js
@@ -588,6 +588,43 @@ describe('sharethrough adapter spec', function () {
         });
       });
 
+      describe('cookie deprecation', () => {
+        it('should not add cdep if we do not get it in an impression request', () => {
+          const builtRequests = spec.buildRequests(bidRequests, {
+            auctionId: 'new-auction-id',
+            ortb2: {
+              device: {
+                ext: {
+                  propThatIsNotCdep: 'value-we-dont-care-about',
+                },
+              },
+            },
+          });
+          const noCdep = builtRequests.every((builtRequest) => {
+            const ourCdepValue = builtRequest.data.device?.ext?.cdep;
+            return ourCdepValue === undefined;
+          });
+          expect(noCdep).to.be.true;
+        });
+
+        it('should add cdep if we DO get it in an impression request', () => {
+          const builtRequests = spec.buildRequests(bidRequests, {
+            auctionId: 'new-auction-id',
+            ortb2: {
+              device: {
+                ext: {
+                  cdep: 'cdep-value',
+                },
+              },
+            },
+          });
+          const cdepPresent = builtRequests.every((builtRequest) => {
+            return builtRequest.data.device.ext.cdep === 'cdep-value';
+          });
+          expect(cdepPresent).to.be.true;
+        });
+      });
+
       describe('first party data', () => {
         const firstPartyData = {
           site: {


### PR DESCRIPTION
## Type of change
- [x ] Feature

## Description of change
Updating the request-building logic of the Sharethrough bid adapter so that it passes along `cdep` if received from the impression request.